### PR TITLE
fix test for radix handler

### DIFF
--- a/handler/radixhandler/radixhandler_test.go
+++ b/handler/radixhandler/radixhandler_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yowcow/goromdb/testutil"
 )
 
-var sampleDataFile = "../../data/store/sample-data.json"
+var sampleDataFile = "testdata/sample-data.json"
 
 func TestNew(t *testing.T) {
 	stg := jsonstorage.New(false)

--- a/handler/radixhandler/testdata/sample-data.json
+++ b/handler/radixhandler/testdata/sample-data.json
@@ -1,0 +1,7 @@
+{
+    "hoge": "hoge!",
+    "fuga": "fuga!!",
+    "foo": "foo!!!",
+    "bar": "bar!!!!",
+    "buz": "buz!!!!!"
+}


### PR DESCRIPTION
For fixing test, copy data/sample-data.json under radixhandler
directory. It makes test environment simple.

Test for other handlers still failed. It should be fixed in other
patches.