### PR TITLE
fix bdb seg fault

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/ajiyoshi-vg/goberkeleydb"
   packages = ["bdb"]
-  revision = "0eb4ff0e9ca69c476310ec21eb89bb73ed201978"
+  revision = "94781d9018db078396807d7e084ab7a17fcc0210"
 
 [[projects]]
   branch = "master"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -69,15 +69,15 @@ func (s TestStorage) Load(file string, mux *sync.RWMutex) error {
 	return nil
 }
 
+func (s TestStorage) LoadAndIterate(file string, fn storage.IterationFunc, mux *sync.RWMutex) error {
+	return fmt.Errorf("iteration not supported")
+}
+
 func (s TestStorage) Get(key []byte) ([]byte, error) {
 	if v, ok := s.data[string(key)]; ok {
 		return []byte(v), nil
 	}
 	return nil, storage.KeyNotFoundError(key)
-}
-
-func (s TestStorage) Iterate(fn storage.IterationFunc) error {
-	return fmt.Errorf("iteration not supported")
 }
 
 func TestHandleConn(t *testing.T) {

--- a/storage/bdbstorage/bdbstorage_test.go
+++ b/storage/bdbstorage/bdbstorage_test.go
@@ -47,6 +47,30 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestLoadAndIterate(t *testing.T) {
+	s := New()
+	mux := new(sync.RWMutex)
+
+	data := make(map[string]string)
+	expected := [][]byte{
+		[]byte("hoge"),
+		[]byte("fuga"),
+		[]byte("foo"),
+		[]byte("bar"),
+		[]byte("buz"),
+	}
+	iterFunc := func(k, v []byte) error {
+		assert.Contains(t, expected, k)
+		data[string(k)] = string(v)
+		return nil
+	}
+
+	err := s.LoadAndIterate(sampleDBFile, iterFunc, mux)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 5, len(data))
+}
+
 func TestGet(t *testing.T) {
 	s := New()
 	mux := new(sync.RWMutex)
@@ -80,34 +104,4 @@ func TestGet(t *testing.T) {
 			assert.Equal(t, c.expected, v)
 		})
 	}
-}
-
-func TestIterate(t *testing.T) {
-	s := New()
-
-	data := make(map[string]string)
-	expected := [][]byte{
-		[]byte("hoge"),
-		[]byte("fuga"),
-		[]byte("foo"),
-		[]byte("bar"),
-		[]byte("buz"),
-	}
-	iterFunc := func(k, v []byte) error {
-		assert.Contains(t, expected, k)
-		data[string(k)] = string(v)
-		return nil
-	}
-
-	err := s.Iterate(iterFunc)
-
-	assert.NotNil(t, err)
-
-	mux := new(sync.RWMutex)
-	s.Load(sampleDBFile, mux)
-
-	err = s.Iterate(iterFunc)
-
-	assert.Nil(t, err)
-	assert.Equal(t, 5, len(data))
 }

--- a/storage/boltstorage/boltstorage_test.go
+++ b/storage/boltstorage/boltstorage_test.go
@@ -53,6 +53,30 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestLoadAndIterate(t *testing.T) {
+	s := New("goromdb")
+	mux := new(sync.RWMutex)
+
+	data := make(map[string]string)
+	expected := [][]byte{
+		[]byte("hoge"),
+		[]byte("fuga"),
+		[]byte("foo"),
+		[]byte("bar"),
+		[]byte("buz"),
+	}
+	iterFunc := func(k, v []byte) error {
+		assert.Contains(t, expected, k)
+		data[string(k)] = string(v)
+		return nil
+	}
+
+	err := s.LoadAndIterate(sampleDBFile, iterFunc, mux)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 5, len(data))
+}
+
 func TestGet(t *testing.T) {
 	s := New("goromdb")
 	mux := new(sync.RWMutex)
@@ -86,35 +110,4 @@ func TestGet(t *testing.T) {
 			assert.Equal(t, c.expectedVal, v)
 		})
 	}
-}
-
-func TestIterate(t *testing.T) {
-	s := New("goromdb")
-
-	data := make(map[string]string)
-	expected := [][]byte{
-		[]byte("hoge"),
-		[]byte("fuga"),
-		[]byte("foo"),
-		[]byte("bar"),
-		[]byte("buz"),
-	}
-	iterFunc := func(k, v []byte) error {
-		assert.Contains(t, expected, k)
-		data[string(k)] = string(v)
-		return nil
-	}
-
-	err := s.Iterate(iterFunc)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, 0, len(data))
-
-	mux := new(sync.RWMutex)
-	s.Load(sampleDBFile, mux)
-
-	err = s.Iterate(iterFunc)
-
-	assert.Nil(t, err)
-	assert.Equal(t, 5, len(data))
 }

--- a/storage/jsonstorage/jsonstorage_test.go
+++ b/storage/jsonstorage/jsonstorage_test.go
@@ -61,6 +61,30 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+func TestLoadAndIterate(t *testing.T) {
+	s := New(false)
+	mux := new(sync.RWMutex)
+
+	data := make(map[string]string)
+	expected := [][]byte{
+		[]byte("hoge"),
+		[]byte("fuga"),
+		[]byte("foo"),
+		[]byte("bar"),
+		[]byte("buz"),
+	}
+	iterFunc := func(k, v []byte) error {
+		assert.Contains(t, expected, k)
+		data[string(k)] = string(v)
+		return nil
+	}
+
+	err := s.LoadAndIterate(sampleDataFile, iterFunc, mux)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 5, len(data))
+}
+
 func TestGet(t *testing.T) {
 	s := New(false)
 	mux := new(sync.RWMutex)
@@ -94,35 +118,4 @@ func TestGet(t *testing.T) {
 			assert.Equal(t, c.expectedVal, v)
 		})
 	}
-}
-
-func TestIterate(t *testing.T) {
-	s := New(false)
-
-	data := make(map[string]string)
-	expected := [][]byte{
-		[]byte("hoge"),
-		[]byte("fuga"),
-		[]byte("foo"),
-		[]byte("bar"),
-		[]byte("buz"),
-	}
-	iterFunc := func(k, v []byte) error {
-		assert.Contains(t, expected, k)
-		data[string(k)] = string(v)
-		return nil
-	}
-
-	err := s.Iterate(iterFunc)
-
-	assert.NotNil(t, err)
-	assert.Equal(t, 0, len(data))
-
-	mux := new(sync.RWMutex)
-	s.Load(sampleDataFile, mux)
-
-	err = s.Iterate(iterFunc)
-
-	assert.Nil(t, err)
-	assert.Equal(t, 5, len(data))
 }

--- a/storage/memcdstorage/memcdstorage.go
+++ b/storage/memcdstorage/memcdstorage.go
@@ -24,6 +24,10 @@ func (s Storage) Load(file string, mux *sync.RWMutex) error {
 	return s.proxy.Load(file, mux)
 }
 
+func (s Storage) LoadAndIterate(file string, fn storage.IterationFunc, mux *sync.RWMutex) error {
+	return s.proxy.LoadAndIterate(file, fn, mux)
+}
+
 func (s Storage) Get(key []byte) ([]byte, error) {
 	val, err := s.proxy.Get(key)
 	if err != nil {
@@ -35,10 +39,6 @@ func (s Storage) Get(key []byte) ([]byte, error) {
 		return nil, storage.KeyNotFoundError(key)
 	}
 	return v, nil
-}
-
-func (s Storage) Iterate(fn storage.IterationFunc) error {
-	return s.proxy.Iterate(fn)
 }
 
 // Serialize serializes given key and value into MemcacheDB format binary, and writes to writer

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -10,7 +10,7 @@ type IterationFunc func([]byte, []byte) error
 type Storage interface {
 	Get([]byte) ([]byte, error)
 	Load(string, *sync.RWMutex) error
-	Iterate(IterationFunc) error
+	LoadAndIterate(string, IterationFunc, *sync.RWMutex) error
 }
 
 func KeyNotFoundError(key []byte) error {


### PR DESCRIPTION
Fixes #57 

Avoid `db.Get()` operation while iteration is in progress changing db switching operation order.

+ `storage.Load()`: open new db, and replace it with current db
+ `storage.LoadAndIterate()`: open new db, iterate, and replace it with current db