### PR TITLE
fix bdb segmentation violation

### DIFF
--- a/handler/radixhandler/radixhandler.go
+++ b/handler/radixhandler/radixhandler.go
@@ -74,7 +74,7 @@ func (h *Handler) Load(file string) error {
 		return nil
 	}
 
-	err := h.storage.LoadAndIterate(file, fn, h.mux)
+	err := h.storage.LoadAndIterate(file, fn)
 	if err != nil {
 		return err
 	}
@@ -89,9 +89,8 @@ func (h *Handler) Load(file string) error {
 
 func (h Handler) Get(key []byte) ([]byte, []byte, error) {
 	h.mux.RLock()
-	defer h.mux.RUnlock()
-
 	prefix, _, ok := h.tree.LongestPrefix(string(key))
+	h.mux.RUnlock()
 	if !ok {
 		return nil, nil, storage.KeyNotFoundError(key)
 	}

--- a/handler/simplehandler/simplehandler.go
+++ b/handler/simplehandler/simplehandler.go
@@ -2,7 +2,6 @@ package simplehandler
 
 import (
 	"log"
-	"sync"
 
 	"github.com/yowcow/goromdb/handler"
 	"github.com/yowcow/goromdb/loader"
@@ -11,14 +10,12 @@ import (
 
 type Handler struct {
 	storage storage.Storage
-	mux     *sync.RWMutex
 	logger  *log.Logger
 }
 
 func New(stg storage.Storage, logger *log.Logger) handler.Handler {
 	return &Handler{
 		stg,
-		new(sync.RWMutex),
 		logger,
 	}
 }
@@ -63,12 +60,10 @@ func (h Handler) start(filein <-chan string, l *loader.Loader, done chan<- bool)
 }
 
 func (h Handler) Load(file string) error {
-	return h.storage.Load(file, h.mux)
+	return h.storage.Load(file)
 }
 
 func (h Handler) Get(key []byte) ([]byte, []byte, error) {
-	h.mux.RLock()
-	defer h.mux.RUnlock()
 	val, err := h.storage.Get(key)
 	if err != nil {
 		return nil, nil, err

--- a/server/server.go
+++ b/server/server.go
@@ -48,11 +48,7 @@ func (s Server) Start() error {
 
 // HandleConn handles a net.Conn
 func (s Server) HandleConn(conn net.Conn) {
-	defer func() {
-		s.logger.Println("server got a client connection closed")
-		conn.Close()
-	}()
-	s.logger.Println("server got a new client connection")
+	defer conn.Close()
 	r := bufio.NewReader(conn)
 	for {
 		line, _, err := r.ReadLine()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,11 +64,11 @@ func createTestStorage(logger *log.Logger) storage.Storage {
 	return &TestStorage{data, logger}
 }
 
-func (s TestStorage) Load(file string, mux *sync.RWMutex) error {
+func (s TestStorage) Load(file string) error {
 	return nil
 }
 
-func (s TestStorage) LoadAndIterate(file string, fn storage.IterationFunc, mux *sync.RWMutex) error {
+func (s TestStorage) LoadAndIterate(file string, fn storage.IterationFunc) error {
 	return fmt.Errorf("iteration not supported")
 }
 

--- a/storage/bdbstorage/bdbstorage.go
+++ b/storage/bdbstorage/bdbstorage.go
@@ -9,14 +9,14 @@ import (
 )
 
 type Storage struct {
-	mux *sync.Mutex
 	db  *atomic.Value
+	mux *sync.Mutex
 }
 
 func New() *Storage {
 	return &Storage{
-		new(sync.Mutex),
 		new(atomic.Value),
+		new(sync.Mutex),
 	}
 }
 

--- a/storage/bdbstorage/bdbstorage_test.go
+++ b/storage/bdbstorage/bdbstorage_test.go
@@ -1,7 +1,6 @@
 package bdbstorage
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,11 +36,10 @@ func TestLoad(t *testing.T) {
 		},
 	}
 
-	mux := new(sync.RWMutex)
 	for _, c := range cases {
 		t.Run(c.subtest, func(t *testing.T) {
 			s := New()
-			err := s.Load(c.input, mux)
+			err := s.Load(c.input)
 			assert.Equal(t, c.expectError, err != nil)
 		})
 	}
@@ -49,7 +47,6 @@ func TestLoad(t *testing.T) {
 
 func TestLoadAndIterate(t *testing.T) {
 	s := New()
-	mux := new(sync.RWMutex)
 
 	data := make(map[string]string)
 	expected := [][]byte{
@@ -65,7 +62,7 @@ func TestLoadAndIterate(t *testing.T) {
 		return nil
 	}
 
-	err := s.LoadAndIterate(sampleDBFile, iterFunc, mux)
+	err := s.LoadAndIterate(sampleDBFile, iterFunc)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(data))
@@ -73,8 +70,7 @@ func TestLoadAndIterate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	s := New()
-	mux := new(sync.RWMutex)
-	s.Load(sampleDBFile, mux)
+	s.Load(sampleDBFile)
 
 	type Case struct {
 		input       []byte

--- a/storage/bdbstorage/bdbstorage_test.go
+++ b/storage/bdbstorage/bdbstorage_test.go
@@ -70,6 +70,11 @@ func TestLoadAndIterate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	s := New()
+	v, err := s.Get([]byte("hoge"))
+
+	assert.Nil(t, v)
+	assert.NotNil(t, err)
+
 	s.Load(sampleDBFile)
 
 	type Case struct {

--- a/storage/boltstorage/boltstorage.go
+++ b/storage/boltstorage/boltstorage.go
@@ -10,62 +10,77 @@ import (
 type Storage struct {
 	db     *bolt.DB
 	bucket []byte
+	mux    *sync.RWMutex
 }
 
 func New(b string) *Storage {
-	return &Storage{nil, []byte(b)}
+	return &Storage{
+		nil,
+		[]byte(b),
+		new(sync.RWMutex),
+	}
 }
 
-func (s *Storage) Load(file string, mux *sync.RWMutex) error {
-	db, err := openDB(file)
+func (s *Storage) Load(file string) error {
+	newDB, err := openDB(file)
 	if err != nil {
 		return err
 	}
 
-	mux.Lock()
-	defer mux.Unlock()
+	s.mux.Lock()
+	defer s.mux.Unlock()
 
-	if s.db != nil {
-		s.db.Close()
+	if oldDB := s.getDB(); oldDB != nil {
+		oldDB.Close()
 	}
-	s.db = db
+	s.db = newDB
 	return nil
 }
 
-func (s *Storage) LoadAndIterate(file string, fn storage.IterationFunc, mux *sync.RWMutex) error {
-	db, err := openDB(file)
+func (s *Storage) LoadAndIterate(file string, fn storage.IterationFunc) error {
+	newDB, err := openDB(file)
 	if err != nil {
 		return err
 	}
-	err = iterate(db, s.bucket, fn)
+	err = iterate(newDB, s.bucket, fn)
 	if err != nil {
 		return err
 	}
 
-	mux.Lock()
-	defer mux.Unlock()
+	s.mux.Lock()
+	defer s.mux.Unlock()
 
-	if s.db != nil {
-		s.db.Close()
+	if oldDB := s.getDB(); oldDB != nil {
+		oldDB.Close()
 	}
-	s.db = db
+	s.db = newDB
 	return nil
 }
 
-func (s Storage) Get(key []byte) ([]byte, error) {
-	var val []byte
-	s.db.View(func(tx *bolt.Tx) error {
-		val = tx.Bucket(s.bucket).Get(key)
-		return nil
-	})
-	if val == nil {
-		return nil, storage.KeyNotFoundError(key)
-	}
-	return val, nil
+func (s Storage) getDB() *bolt.DB {
+	return s.db
 }
 
 func openDB(file string) (*bolt.DB, error) {
 	return bolt.Open(file, 0644, &bolt.Options{ReadOnly: true})
+}
+
+func (s Storage) Get(key []byte) ([]byte, error) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+
+	if db := s.getDB(); db != nil {
+		var val []byte
+		db.View(func(tx *bolt.Tx) error {
+			val = tx.Bucket(s.bucket).Get(key)
+			return nil
+		})
+		if val == nil {
+			return nil, storage.KeyNotFoundError(key)
+		}
+		return val, nil
+	}
+	return nil, storage.KeyNotFoundError(key)
 }
 
 func iterate(db *bolt.DB, bucket []byte, fn storage.IterationFunc) error {

--- a/storage/boltstorage/boltstorage_test.go
+++ b/storage/boltstorage/boltstorage_test.go
@@ -76,6 +76,11 @@ func TestLoadAndIterate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	s := New("goromdb")
+	v, err := s.Get([]byte("hoge"))
+
+	assert.Nil(t, v)
+	assert.NotNil(t, err)
+
 	s.Load(sampleDBFile)
 
 	type Case struct {

--- a/storage/boltstorage/boltstorage_test.go
+++ b/storage/boltstorage/boltstorage_test.go
@@ -1,7 +1,6 @@
 package boltstorage
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,6 @@ func TestNew(t *testing.T) {
 
 func TestLoad(t *testing.T) {
 	s := New("goromdb")
-	mux := new(sync.RWMutex)
 
 	type Case struct {
 		input       string
@@ -47,7 +45,7 @@ func TestLoad(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.subtest, func(t *testing.T) {
-			err := s.Load(sampleDBFile, mux)
+			err := s.Load(sampleDBFile)
 			assert.Equal(t, c.expectError, err != nil)
 		})
 	}
@@ -55,7 +53,6 @@ func TestLoad(t *testing.T) {
 
 func TestLoadAndIterate(t *testing.T) {
 	s := New("goromdb")
-	mux := new(sync.RWMutex)
 
 	data := make(map[string]string)
 	expected := [][]byte{
@@ -71,7 +68,7 @@ func TestLoadAndIterate(t *testing.T) {
 		return nil
 	}
 
-	err := s.LoadAndIterate(sampleDBFile, iterFunc, mux)
+	err := s.LoadAndIterate(sampleDBFile, iterFunc)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(data))
@@ -79,8 +76,7 @@ func TestLoadAndIterate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	s := New("goromdb")
-	mux := new(sync.RWMutex)
-	s.Load(sampleDBFile, mux)
+	s.Load(sampleDBFile)
 
 	type Case struct {
 		input       []byte

--- a/storage/jsonstorage/jsonstorage_test.go
+++ b/storage/jsonstorage/jsonstorage_test.go
@@ -84,6 +84,11 @@ func TestLoadAndIterate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	s := New(false)
+	v, err := s.Get([]byte("hoge"))
+
+	assert.Nil(t, v)
+	assert.NotNil(t, err)
+
 	s.Load(sampleDataFile)
 
 	type Case struct {

--- a/storage/jsonstorage/jsonstorage_test.go
+++ b/storage/jsonstorage/jsonstorage_test.go
@@ -1,7 +1,6 @@
 package jsonstorage
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,11 +50,10 @@ func TestLoad(t *testing.T) {
 		},
 	}
 
-	mux := new(sync.RWMutex)
 	for _, c := range cases {
 		t.Run(c.subtest, func(t *testing.T) {
 			s := New(c.gzipped)
-			err := s.Load(c.input, mux)
+			err := s.Load(c.input)
 			assert.Equal(t, c.expectError, err != nil)
 		})
 	}
@@ -63,7 +61,6 @@ func TestLoad(t *testing.T) {
 
 func TestLoadAndIterate(t *testing.T) {
 	s := New(false)
-	mux := new(sync.RWMutex)
 
 	data := make(map[string]string)
 	expected := [][]byte{
@@ -79,7 +76,7 @@ func TestLoadAndIterate(t *testing.T) {
 		return nil
 	}
 
-	err := s.LoadAndIterate(sampleDataFile, iterFunc, mux)
+	err := s.LoadAndIterate(sampleDataFile, iterFunc)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(data))
@@ -87,8 +84,7 @@ func TestLoadAndIterate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	s := New(false)
-	mux := new(sync.RWMutex)
-	s.Load(sampleDataFile, mux)
+	s.Load(sampleDataFile)
 
 	type Case struct {
 		input       []byte

--- a/storage/memcdstorage/memcdstorage.go
+++ b/storage/memcdstorage/memcdstorage.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"sync"
 
 	"github.com/yowcow/goromdb/storage"
 )
@@ -20,12 +19,12 @@ func New(proxy storage.Storage) *Storage {
 	return &Storage{proxy}
 }
 
-func (s Storage) Load(file string, mux *sync.RWMutex) error {
-	return s.proxy.Load(file, mux)
+func (s Storage) Load(file string) error {
+	return s.proxy.Load(file)
 }
 
-func (s Storage) LoadAndIterate(file string, fn storage.IterationFunc, mux *sync.RWMutex) error {
-	return s.proxy.LoadAndIterate(file, fn, mux)
+func (s Storage) LoadAndIterate(file string, fn storage.IterationFunc) error {
+	return s.proxy.LoadAndIterate(file, fn)
 }
 
 func (s Storage) Get(key []byte) ([]byte, error) {

--- a/storage/memcdstorage/memcdstorage_test.go
+++ b/storage/memcdstorage/memcdstorage_test.go
@@ -51,6 +51,11 @@ func TestLoad(t *testing.T) {
 func TestGet(t *testing.T) {
 	p := bdbstorage.New()
 	s := New(p)
+	v, err := s.Get([]byte("hoge"))
+
+	assert.Nil(t, v)
+	assert.NotNil(t, err)
+
 	s.Load(sampleDBFile)
 
 	type Case struct {

--- a/storage/memcdstorage/memcdstorage_test.go
+++ b/storage/memcdstorage/memcdstorage_test.go
@@ -1,7 +1,6 @@
 package memcdstorage
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,12 +38,11 @@ func TestLoad(t *testing.T) {
 		},
 	}
 
-	mux := new(sync.RWMutex)
 	for _, c := range cases {
 		t.Run(c.subtest, func(t *testing.T) {
 			p := bdbstorage.New()
 			s := New(p)
-			err := s.Load(c.input, mux)
+			err := s.Load(c.input)
 			assert.Equal(t, c.expectError, err != nil)
 		})
 	}
@@ -53,8 +51,7 @@ func TestLoad(t *testing.T) {
 func TestGet(t *testing.T) {
 	p := bdbstorage.New()
 	s := New(p)
-	mux := new(sync.RWMutex)
-	s.Load(sampleDBFile, mux)
+	s.Load(sampleDBFile)
 
 	type Case struct {
 		input       []byte

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,15 +2,14 @@ package storage
 
 import (
 	"fmt"
-	"sync"
 )
 
 type IterationFunc func([]byte, []byte) error
 
 type Storage interface {
 	Get([]byte) ([]byte, error)
-	Load(string, *sync.RWMutex) error
-	LoadAndIterate(string, IterationFunc, *sync.RWMutex) error
+	Load(string) error
+	LoadAndIterate(string, IterationFunc) error
 }
 
 func KeyNotFoundError(key []byte) error {


### PR DESCRIPTION
to fix #62, change database handling as followings:

+ storages to put db handles into `atomic.Value` to make sure non-atomic pointer operations to be in sync
+ do `mutex.Lock()`, not `mutex.RLock()`, on `bdb.Get()` operation to make sure only 1 `Get` occurs at a time