### PR TITLE
add error type

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,6 +7,16 @@ import (
 // IterationFunc defines an interface to a callback function for LoadAndIterate()
 type IterationFunc func([]byte, []byte) error
 
+// ErrorKeyNotFound key-not-found error type
+type ErrorKeyNotFound struct {
+	error
+}
+
+// ErrorInternal internal error
+type ErrorInternal struct {
+	error
+}
+
 // Storage defines an interface to a storage
 type Storage interface {
 	Get([]byte) ([]byte, error)
@@ -16,5 +26,26 @@ type Storage interface {
 
 // KeyNotFoundError returns an error for key-not-found
 func KeyNotFoundError(key []byte) error {
-	return fmt.Errorf("key not found error: %s", string(key))
+	return &ErrorKeyNotFound{
+		fmt.Errorf("key not found error: %s", string(key)),
+	}
+}
+
+// InternalError something go wrong internal
+func InternalError(s string) error {
+	return &ErrorInternal{
+		fmt.Errorf(s),
+	}
+}
+
+// IsErrorKeyNotFound returns if it is an ErrorKeyNotFound
+func IsErrorKeyNotFound(err error) bool {
+	switch err.(type) {
+	case ErrorKeyNotFound:
+		return true
+	case *ErrorKeyNotFound:
+		return true
+	default:
+		return false
+	}
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsErrorKeytNotFound(t *testing.T) {
+	type Case struct {
+		msg    string
+		err    error
+		expect bool
+	}
+
+	cases := []Case{
+		{
+			"KeyNotFoundError()",
+			KeyNotFoundError([]byte("an_key")),
+			true,
+		},
+		{
+			"ErrorKeyNotFound{} struct",
+			ErrorKeyNotFound{fmt.Errorf("struct")},
+			true,
+		},
+		{
+			"*ErrorKeyNotFound{} pointer",
+			&ErrorKeyNotFound{fmt.Errorf("pointer")},
+			true,
+		},
+		{
+			"InternalError()",
+			InternalError("go wrong"),
+			false,
+		},
+		{
+			"usual error",
+			fmt.Errorf("usual error"),
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.msg, func(t *testing.T) {
+			actual := IsErrorKeyNotFound(c.err)
+			if actual != c.expect {
+				t.Fatalf("(%v) want %v got %v", c.err, c.expect, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* I want to add key-not-found error type
* The error that KVS can not find a key is very casual so I want to distinguish it from a critical error such as not being able to load a DB.