### PR TITLE
Add dep if not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ all:
 	$(MAKE) -j 4 $(DB_PATHS) $(MD5_PATHS) $(BINARY)
 
 dep:
+	which dep || go get -u -v github.com/golang/dep/cmd/dep
 	dep ensure -v
 
 test:


### PR DESCRIPTION
I got this in my fresh box:

```
make[1]: dep: Command not found
Makefile:19: recipe for target 'dep' failed
make[1]: *** [dep] Error 127
```