### PR TITLE
Improve watcher logging

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -64,7 +64,7 @@ func verifyFile(file, md5file string) (bool, error) {
 
 	md5fi, err := os.Open(md5file)
 	if err != nil {
-		return false, fmt.Errorf("file %s found but %s is not found", file, md5file)
+		return false, fmt.Errorf("file %s is found but %s is not found", file, md5file)
 	}
 	defer md5fi.Close()
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -64,7 +64,7 @@ func verifyFile(file, md5file string) (bool, error) {
 
 	md5fi, err := os.Open(md5file)
 	if err != nil {
-		return false, nil
+		return false, fmt.Errorf("file %s found but %s is not found", file, md5file)
 	}
 	defer md5fi.Close()
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -47,7 +47,7 @@ func (w Watcher) watch(ctx context.Context, out chan<- string) {
 				os.Remove(w.md5file)
 				out <- w.File
 			} else if err != nil {
-				w.logger.Println("watcher file verification failed ", err.Error())
+				w.logger.Println("watcher file verification failed:", err.Error())
 			}
 		case <-ctx.Done():
 			return

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -22,7 +22,7 @@ func TestVerifyFile(t *testing.T) {
 	}
 	cases := []Case{
 		{"non-existing.txt", "non-existing.txt.md5", false, false, "non-existing file"},
-		{"valid.txt", "non-existing.txt.md5", false, false, "non-existing md5 file"},
+		{"valid.txt", "non-existing.txt.md5", false, true, "non-existing md5 file"},
 		{"valid.txt", "invalid-len.txt.md5", false, true, "invalid md5 length"},
 		{"valid.txt", "invalid-sum.txt.md5", false, true, "invalid md5 sum"},
 		{"valid.txt", "valid.txt.md5", true, false, "valid md5"},
@@ -63,8 +63,8 @@ func TestStart(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 	out := wcr.Start(ctx)
-	<-out
 	cancel()
+	<-out // out should get closed after cancel() call
 }
 
 func TestWatchOutput(t *testing.T) {
@@ -85,7 +85,7 @@ func TestWatchOutput(t *testing.T) {
 
 	loadedFile := <-out
 	cancel()
-	<-out
+	<-out // out should get closed after cancel() call
 
 	assert.Equal(t, file, loadedFile)
 


### PR DESCRIPTION
For #77 

+ log when data file is found but md5 file is not found
+ fix watcher testing