### PR TITLE
Clone read []byte after retrieving from boltdb

### DIFF
--- a/storage/boltstorage/storage.go
+++ b/storage/boltstorage/storage.go
@@ -80,5 +80,13 @@ func getFromBucket(db *bolt.DB, bucket, key []byte) ([]byte, error) {
 		}
 		return nil
 	})
-	return val, err
+
+	if err != nil {
+		return nil, err
+	}
+
+	retVal := make([]byte, len(val))
+	copy(retVal, val)
+
+	return retVal, nil
 }

--- a/storage/boltstorage/storage.go
+++ b/storage/boltstorage/storage.go
@@ -69,6 +69,7 @@ func (s *Storage) Get(key []byte) ([]byte, error) {
 
 func getFromBucket(db *bolt.DB, bucket, key []byte) ([]byte, error) {
 	var val []byte
+
 	err := db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucket)
 		if b == nil {
@@ -80,7 +81,6 @@ func getFromBucket(db *bolt.DB, bucket, key []byte) ([]byte, error) {
 		}
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/storage/boltstorage/storage.go
+++ b/storage/boltstorage/storage.go
@@ -85,6 +85,8 @@ func getFromBucket(db *bolt.DB, bucket, key []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	// Making sure that []byte is safe.
+	// Without copy, returning []byte may be corrupted at the time of reference later on.
 	retVal := make([]byte, len(val))
 	copy(retVal, val)
 


### PR DESCRIPTION
During file switching, []byte read from boltdb gets corrupted at the time of use.

To avoid this issue, clone read bytes into new []byte slice just after retrieving from boltdb.