### PR TITLE
Return ErrorBucketNotFound when bucket is not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
 - "1.10"
 - "1.11"
+- "1.12"
 addons:
   apt:
     packages:

--- a/storage/boltstorage/storage.go
+++ b/storage/boltstorage/storage.go
@@ -1,7 +1,6 @@
 package boltstorage
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -73,7 +72,7 @@ func getFromBucket(db *bolt.DB, bucket, key []byte) ([]byte, error) {
 	err := db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucket)
 		if b == nil {
-			return storage.InternalError(fmt.Sprintf("bucket %v not found", bucket))
+			return storage.BucketNotFoundError(bucket)
 		}
 
 		val := b.Get(key)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -16,6 +16,11 @@ type NSStorage interface {
 	GetNS(namespace, key []byte) ([]byte, error)
 }
 
+// ErrorBucketNotFound bucket-not-found error type
+type ErrorBucketNotFound struct {
+	error
+}
+
 // ErrorKeyNotFound key-not-found error type
 type ErrorKeyNotFound struct {
 	error
@@ -24,6 +29,13 @@ type ErrorKeyNotFound struct {
 // ErrorInternal internal error
 type ErrorInternal struct {
 	error
+}
+
+// BucketNotFoundError returns an error for bucket-not-found
+func BucketNotFoundError(bucket []byte) error {
+	return &ErrorBucketNotFound{
+		fmt.Errorf("bucket not found error: %s", string(bucket)),
+	}
 }
 
 // KeyNotFoundError returns an error for key-not-found
@@ -37,6 +49,18 @@ func KeyNotFoundError(key []byte) error {
 func InternalError(s string) error {
 	return &ErrorInternal{
 		fmt.Errorf(s),
+	}
+}
+
+// IsErrorBucketNotFound returns if it is an ErrorBucketNotFound
+func IsErrorBucketNotFound(err error) bool {
+	switch err.(type) {
+	case ErrorBucketNotFound:
+		return true
+	case *ErrorBucketNotFound:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -48,3 +48,47 @@ func TestIsErrorKeytNotFound(t *testing.T) {
 		})
 	}
 }
+
+func TestIsErrorBuckettNotFound(t *testing.T) {
+	type Case struct {
+		msg    string
+		err    error
+		expect bool
+	}
+
+	cases := []Case{
+		{
+			"BucketNotFoundError()",
+			BucketNotFoundError([]byte("an_key")),
+			true,
+		},
+		{
+			"ErrorBucketNotFound{} struct",
+			ErrorBucketNotFound{fmt.Errorf("struct")},
+			true,
+		},
+		{
+			"*ErrorBucketNotFound{} pointer",
+			&ErrorBucketNotFound{fmt.Errorf("pointer")},
+			true,
+		},
+		{
+			"InternalError()",
+			InternalError("go wrong"),
+			false,
+		},
+		{
+			"usual error",
+			fmt.Errorf("usual error"),
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.msg, func(t *testing.T) {
+			actual := IsErrorBucketNotFound(c.err)
+			if actual != c.expect {
+				t.Fatalf("(%v) want %v got %v", c.err, c.expect, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Some goromdb server implementation requires to handle "bucket not found" error, other than just an InternalError, on such occasions like it can be just another kind of key not found error.

To make it possible, add another error type `ErrorBucketNotFound`, and return it explicitly when bucket is not found.